### PR TITLE
added no_command for test when notr in dev

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,6 +89,7 @@ client.on("messageCreate", (message) => {
     case COMMANDS.test:
       if (process.env.BOT_ENV === "DEV")
         test_command(message, command, commandBody, args, argsAsString);
+      else no_command(message);
       break;
     // No Command - $smurf
     case undefined:


### PR DESCRIPTION
- $smurf test would respond with nothing, should now indicate that it is not a valid command while not in dev