### PR TITLE
changed elo override on error responses to -1

### DIFF
--- a/command_functions/ranks_command.js
+++ b/command_functions/ranks_command.js
@@ -70,7 +70,7 @@ const ranksCommand = async (message, command, args) => {
                 currenttierpatched: "Error",
                 name: accountData[index].name,
                 tag: accountData[index].tag,
-                elo: 0,
+                elo: -1,
                 errors: data.errors,
               };
             }


### PR DESCRIPTION
- changed `elo` override on error responses to `-1` so that error response accounts come after `Unrated` accounts when the `$smurf ranks` command is called.